### PR TITLE
fixed compiler version in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,8 +11,15 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.3</version>
         <configuration>
-          <source/>
-          <target/>
+			<source>1.8</source>
+			<target>1.8</target>
+			<optimize>true</optimize>
+			<showWarnings>true</showWarnings>
+			<showDeprecation>true</showDeprecation>
+			<compilerArguments>
+				<Xmaxwarns>10000</Xmaxwarns>
+				<Xmaxerrs>10000</Xmaxerrs>
+			</compilerArguments>
         </configuration>
       </plugin>
     </plugins>


### PR DESCRIPTION
Hey, I finally edited that pom.xml file. Without specifying the compiler version, Eclipse kept on reverting to Java 1.5 and throwing errors on every update.
